### PR TITLE
Send responses to original browser in correct order.

### DIFF
--- a/mirrord/agent/src/error.rs
+++ b/mirrord/agent/src/error.rs
@@ -114,6 +114,9 @@ pub enum AgentError {
 
     #[error("HTTP filter-stealing error: `{0}`")]
     HttpFilterError(#[from] crate::steal::http_traffic::error::HttpTrafficError),
+
+    #[error("Failed to encode a an HTTP response with error: `{0}`")]
+    HttpEncoding(#[from] hyper::http::Error),
 }
 
 pub(crate) type Result<T, E = AgentError> = std::result::Result<T, E>;

--- a/mirrord/agent/src/steal.rs
+++ b/mirrord/agent/src/steal.rs
@@ -4,7 +4,7 @@ use http_body_util::BodyExt;
 use hyper::{body::Incoming, http::request::Parts, Request};
 use mirrord_protocol::{
     tcp::{DaemonTcp, HttpRequest, HttpResponse, InternalHttpRequest, StealType, TcpData},
-    ConnectionId, Port,
+    ConnectionId, Port, RequestId,
 };
 use tokio::{net::TcpListener, select, sync::mpsc::Sender};
 use tokio_util::sync::CancellationToken;
@@ -84,6 +84,7 @@ pub struct StealerHttpRequest {
     pub port: Port,
     pub connection_id: ConnectionId,
     pub client_id: ClientId,
+    pub request_id: RequestId,
     pub request: Request<Incoming>,
 }
 

--- a/mirrord/agent/src/steal.rs
+++ b/mirrord/agent/src/steal.rs
@@ -1,7 +1,11 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use http_body_util::BodyExt;
-use hyper::{body::Incoming, http::request::Parts, Request};
+use hyper::{
+    body::Incoming,
+    http::{request, response},
+    Request,
+};
 use mirrord_protocol::{
     tcp::{DaemonTcp, HttpRequest, HttpResponse, InternalHttpRequest, StealType, TcpData},
     ConnectionId, Port, RequestId,
@@ -91,7 +95,7 @@ pub struct StealerHttpRequest {
 impl StealerHttpRequest {
     async fn into_serializable(self) -> Result<HttpRequest, hyper::Error> {
         let (
-            Parts {
+            request::Parts {
                 method,
                 uri,
                 version,

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -95,7 +95,7 @@ pub(crate) struct TcpConnectionStealer {
     /// Used to send http responses back to the original remote connection.
     http_write_streams: HashMap<ConnectionId, WriteHalf<DefaultReversibleStream>>,
 
-    /// For a connection with pending requests, a priority queue with response that were already
+    /// For a connection with pending requests, a priority queue with responses that were already
     /// returned, but that cannot be sent yet because there are earlier responses that are not
     /// available yet.
     http_response_queues: HashMap<ConnectionId, BinaryHeap<HttpResponse>>,

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -676,8 +676,7 @@ impl TcpConnectionStealer {
     /// Local App --> Layer --> ClientConnectionHandler --> Stealer --> Browser
     ///                                                             ^- You are here.
     async fn http_response(&mut self, response: HttpResponse) -> Result<()> {
-        let tcp_stream_write_half = if let Some(stream) =
-            self.http_write_streams.get_mut(&response.connection_id)
+        let http_tx = if let Some(stream) = self.http_write_streams.get_mut(&response.connection_id)
         {
             stream
         } else {
@@ -696,7 +695,7 @@ impl TcpConnectionStealer {
                 .try_into()
                 .map_err(Self::handle_response_reconstruction_fail)
             {
-                tcp_stream_write_half
+                http_tx
                     .write_all(&Self::response_to_bytes(response).await)
                     .await?; // TODO: handle error?
             }
@@ -714,7 +713,7 @@ impl TcpConnectionStealer {
                         .try_into()
                         .map_err(Self::handle_response_reconstruction_fail)
                     {
-                        tcp_stream_write_half
+                        http_tx
                             .write_all(&Self::response_to_bytes(response).await)
                             .await?; // TODO: handle error?
                     }

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -676,15 +676,16 @@ impl TcpConnectionStealer {
     /// Local App --> Layer --> ClientConnectionHandler --> Stealer --> Browser
     ///                                                             ^- You are here.
     async fn http_response(&mut self, response: HttpResponse) -> Result<()> {
-        let tcp_stream_write_half;
-        if let Some(stream) = self.http_write_streams.get_mut(&response.connection_id) {
-            tcp_stream_write_half = stream;
+        let tcp_stream_write_half = if let Some(stream) =
+            self.http_write_streams.get_mut(&response.connection_id)
+        {
+            stream
         } else {
             warn!(
                 "Got an http response in a connection for which no tcp stream is present. Not forwarding.",
             );
             return Ok(());
-        }
+        };
         let counter = self
             .http_request_counters
             .entry(response.connection_id)

--- a/mirrord/agent/src/steal/http_traffic/filter.rs
+++ b/mirrord/agent/src/steal/http_traffic/filter.rs
@@ -130,6 +130,7 @@ impl HttpFilterBuilder {
                                 passthrough_tx,
                                 connection_id,
                                 port,
+                                request_id: 0,
                             },
                         )
                         .await

--- a/mirrord/layer/src/tcp_steal.rs
+++ b/mirrord/layer/src/tcp_steal.rs
@@ -154,6 +154,8 @@ impl TcpHandler for TcpStealHandler {
 }
 
 impl TcpStealHandler {
+    /// Get the available response data, either normal TcpData, or a response to a filtered HTTP
+    /// request - whatever is ready first.
     pub async fn next(&mut self) -> Option<ClientMessage> {
         select! {
             opt = self.read_streams.next() => {

--- a/mirrord/protocol/src/lib.rs
+++ b/mirrord/protocol/src/lib.rs
@@ -13,8 +13,11 @@ use std::{collections::HashSet, ops::Deref};
 pub use codec::*;
 pub use error::*;
 
-pub type ConnectionId = u64;
 pub type Port = u16;
+pub type ConnectionId = u64;
+
+/// A per-connection HTTP request ID
+pub type RequestId = u16; // TODO: how many requests in a single connection? is u16 appropriate?
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EnvVars(pub String);

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -191,7 +191,7 @@ impl HttpResponse {
             body,
         ) = response.into_parts();
         let body = body.collect().await?.to_bytes().to_vec();
-        let internal_req = InternalHttpResponse {
+        let internal_response = InternalHttpResponse {
             status,
             headers,
             version,
@@ -201,7 +201,7 @@ impl HttpResponse {
             request_id,
             port,
             connection_id,
-            response: internal_req,
+            response: internal_response,
         })
     }
 }

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -1,4 +1,4 @@
-use std::{fmt, net::IpAddr};
+use std::{cmp::Ordering, fmt, net::IpAddr};
 
 use bincode::{Decode, Encode};
 use bytes::Bytes;
@@ -9,7 +9,7 @@ use hyper::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{ConnectionId, Port, RemoteResult};
+use crate::{ConnectionId, Port, RemoteResult, RequestId};
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct NewTcpConnection {
@@ -119,9 +119,6 @@ impl From<InternalHttpRequest> for Request<Full<Bytes>> {
     }
 }
 
-// TODO: is u64 fine?
-type RequestId = u64;
-
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct HttpRequest {
     #[bincode(with_serde)]
@@ -152,19 +149,36 @@ pub struct InternalHttpResponse {
 pub struct HttpResponse {
     /// This is used to make sure the response is sent in its turn, after responses to all earlier
     /// requests were already sent.
-    pub request_id: u64,
-    pub connection_id: ConnectionId,
     pub port: Port,
+    pub connection_id: ConnectionId,
+    pub request_id: RequestId,
     #[bincode(with_serde)]
-    pub request: InternalHttpResponse,
+    pub response: InternalHttpResponse,
 }
 
+impl PartialOrd<Self> for HttpResponse {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// An total order which a request with a LESSER ID is GREATER.
+impl Ord for HttpResponse {
+    /// request1 > request2  iff. request1.request_id < request2.request_id.
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reversed order because we want to process lower request_ids first, so we want a min heap
+        // instead of the default max heap.
+        other.request_id.cmp(&self.request_id)
+    }
+}
+
+// Not implemented as From<Response<Incoming>> because async.
 impl HttpResponse {
     pub async fn from_hyper_response(
         response: Response<Incoming>,
         port: Port,
         connection_id: ConnectionId,
-        request_id: u64,
+        request_id: RequestId,
     ) -> Result<HttpResponse, hyper::Error> {
         let (
             Parts {
@@ -187,7 +201,24 @@ impl HttpResponse {
             request_id,
             port,
             connection_id,
-            request: internal_req,
+            response: internal_req,
         })
+    }
+}
+
+impl From<InternalHttpResponse> for Response<Full<Bytes>> {
+    fn from(value: InternalHttpResponse) -> Self {
+        let InternalHttpResponse {
+            status,
+            version,
+            headers,
+            body,
+        } = value;
+
+        let builder = Response::Builder().status(status).version(version);
+        if let Some(h) = builder.headers_mut() {
+            *h = headers;
+        }
+        builder.body(body)
     }
 }

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -162,7 +162,7 @@ impl PartialOrd<Self> for HttpResponse {
     }
 }
 
-/// An total order which a request with a LESSER ID is GREATER.
+/// A total order of responses in which the response with the LESSER `request_id` is the GREATER one.
 impl Ord for HttpResponse {
     /// request1 > request2  iff. request1.request_id < request2.request_id.
     fn cmp(&self, other: &Self) -> Ordering {


### PR DESCRIPTION
Set a `request_id` for each incoming request, the responses are only sent back to the browser once all earlier responses have been sent.